### PR TITLE
Update PoC checklist for post-workshop

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
+++ b/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
@@ -102,7 +102,7 @@ body:
     attributes:
       label: Estimated Number of Participants
       description: >
-        Please provide an estimate of the number of participants attending  your
+        Please provide an estimate of the number of participants attending your
         workshop.
     validations:
       required: true
@@ -157,7 +157,7 @@ body:
             received and the hub is available for the workshop (a comment in
             this issue thread is fine)
         - label: >
-            **Organizer**: Add your event in the  [workshop
+            **Organizer**: Add your event in the [workshop
             spreadsheet](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382).
             Please check if there are any other workshops scheduled around the
             same time and if so, let the hub PoC know to make sure the hub can
@@ -176,7 +176,7 @@ body:
             in response to ticket
             ([example](https://github.com/2i2c-org/infrastructure/issues/5466))
         - label: >
-            **Hub PoC**: Add new password and dates to  [workshop password
+            **Hub PoC**: Add new password and dates to [workshop password
             spreadsheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=1793413915).
         - label: >
             **Organizer**: Two weeks before event. I have tested the default hub
@@ -185,7 +185,7 @@ body:
         - label: >
             **Organizer**: In the week before the event (or when hub PoC
             indicates password should be live). I tested that the workshop
-            password works  and images work.
+            password works and images work.
         - label: >
             **Organizer**: After the event, open an
             [issue](https://github.com/NMFS-Openscapes/workshop-planning/issues/new?template=NMFS-openscapes-workshop-reporting-template.md)

--- a/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
+++ b/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
@@ -184,17 +184,18 @@ body:
             password should be live). I tested that the workshop password works 
             and images work.
         - label: >
-            **Hub PoC**: After event, put in a 2i2c ticket to remove the 
-            participants directories, cleared shared-public, and reset password.
+            **Hub PoC**: After event, put in a 2i2c ticket to reset password.
         - label: >
             **Organizer**: After the event, open an 
             [issue](https://github.com/NMFS-Openscapes/workshop-planning/issues/new?template=NMFS-openscapes-workshop-reporting-template.md) 
             in the Workshop Planning repo to report back.
-
-  - type: markdown
-    attributes:
-      value: >
-        ---
-
-        _Please click on the "Projects" button below and tick the 
-        "Main Planning" project if it is available to you_
+        - label: >
+            **Hub PoC**: After event, log in to the hub as admin, enumerate the
+            participant directories and update the workshop spreadsheet with the 
+            actual number of participants.
+        - label: >
+            **Hub PoC**: After event, delete the participant directories.
+        - label: >
+            **Hub PoC**: Close the issue. If the workshop was completed, close
+            as "completed". If the workshop was cancelled before being held, 
+            close as "Not Planned" and note in the comments that it was cancelled.

--- a/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
+++ b/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
@@ -5,7 +5,7 @@ labels: "workshop"
 assignees:
   - ateucher
   - eeholmes
-projects: 
+projects:
   - "nmfs-openscapes/35"
 body:
   - type: markdown
@@ -16,11 +16,12 @@ body:
         https://workshop.nmfs-openscapes.2i2c.cloud.
 
 
-        Before submitting, please check the
-        [workshop spreadsheet](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382)
+        Before submitting, please check the [workshop
+        spreadsheet](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382)
         for any existing reservations around your dates. See also the
-        [documentation on openscapes.cloud](https://openscapes.cloud/password-access.html)
-        for detailed instructions.
+        [documentation on
+        openscapes.cloud](https://openscapes.cloud/password-access.html) for
+        detailed instructions.
 
 
         Fill out the form below and we will get back to you as soon as possible
@@ -48,7 +49,7 @@ body:
     attributes:
       label: Workshop End Date
       description: >
-        Please provide the end date of your workshop. Leave blank if it's a 
+        Please provide the end date of your workshop. Leave blank if it's a
         one-day workshop.
       placeholder: YYYY-MM-DD
     validations:
@@ -90,7 +91,8 @@ body:
       description: >
         By default the password will be reset and participants' home directories
         erased seven days after the workshop ends. If you want the participants
-        to have more or less access than the default of seven days, please specify.
+        to have more or less access than the default of seven days, please
+        specify.
       placeholder: YYYY-MM-DD
     validations:
       required: false
@@ -100,8 +102,8 @@ body:
     attributes:
       label: Estimated Number of Participants
       description: >
-        Please provide an estimate of the number of participants attending 
-        your workshop.
+        Please provide an estimate of the number of participants attending  your
+        workshop.
     validations:
       required: true
 
@@ -110,9 +112,9 @@ body:
     attributes:
       label: Compute Requirements
       description: >
-        What size compute resources will participants be asked to select when 
-        they log in? 2Gb (default), 4Gb, more? This is selected in the dropdown 
-        at the Hub login, and knowing what you will need helps us make sure the 
+        What size compute resources will participants be asked to select when
+        they log in? 2Gb (default), 4Gb, more? This is selected in the dropdown
+        at the Hub login, and knowing what you will need helps us make sure the
         hub is adequately provisioned.
     validations:
       required: true
@@ -122,10 +124,10 @@ body:
     attributes:
       label: Image Requirements
       description: >
-        Will you be using one of the default images, or a custom image?
-        Confirm that the image you will be using is sufficient for your needs
-        (i.e., has the packages and sufficient versions you need), or that you
-        have created an image that can be used by participants.
+        Will you be using one of the default images, or a custom image? Confirm
+        that the image you will be using is sufficient for your needs (i.e., has
+        the packages and sufficient versions you need), or that you have created
+        an image that can be used by participants.
     validations:
       required: false
 
@@ -135,10 +137,10 @@ body:
       label: Storage Requirements
       description: >
         Are there any special storage needs? Like will participants need access
-        to large shared files? Do you anticipate that participants might download
-        lots (10s of Gb or more) of data? If so, we will work with you on how best
-        to do that in the workshop. We have a S3 scratch bucket and a shared drive
-        so that we don't have 10s of copies of big data sets.
+        to large shared files? Do you anticipate that participants might
+        download lots (10s of Gb or more) of data? If so, we will work with you
+        on how best to do that in the workshop. We have a S3 scratch bucket and
+        a shared drive so that we don't have 10s of copies of big data sets.
     validations:
       required: false
 
@@ -146,56 +148,58 @@ body:
     id: checklist-organizer-hub-poc
     attributes:
       label: >
-        Checklist for workshop organizer (person planning/leading the workshop) 
-        and hub point-of-contact (PoC; Openscapes team member helping with hub 
+        Checklist for workshop organizer (person planning/leading the workshop)
+        and hub point-of-contact (PoC; Openscapes team member helping with hub
         setup and logistics. Usually @ateucher).
       options:
         - label: >
-            **Hub PoC**: Send confirmation to organizer that the request is 
-            received and the hub is available for the workshop (a comment in 
+            **Hub PoC**: Send confirmation to organizer that the request is
+            received and the hub is available for the workshop (a comment in
             this issue thread is fine)
         - label: >
-            **Organizer**: Add your event in the 
-            [workshop spreadsheet](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382).
-            Please check if there are any other workshops scheduled around the 
-            same time and if so, let the hub PoC know to make sure the hub can 
+            **Organizer**: Add your event in the  [workshop
+            spreadsheet](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382).
+            Please check if there are any other workshops scheduled around the
+            same time and if so, let the hub PoC know to make sure the hub can
             support multiple workshops at the same time.
         - label: >
             **Organizer**: Submit a ticket by email to 2i2c for the workshop and
-            request a new password for the workshop,
-            [as per instructions](https://openscapes.cloud/password-access.html), 
-            cc'ing hub PoC (@ateucher; andy [at] openscapes [dot] org) and 
-            @eeholmes (eli [dot] holmes [at] noaa [dot] gov). You will receive 
-            confirmation of the new password for the workshop from 2i2c once it 
-            is reset. 
+            request a new password for the workshop, [as per
+            instructions](https://openscapes.cloud/password-access.html),
+            cc'ing hub PoC (@ateucher; andy [at] openscapes [dot] org) and
+            @eeholmes (eli [dot] holmes [at] noaa [dot] gov). You will receive
+            confirmation of the new password for the workshop from 2i2c once it
+            is reset.
         - label: >
-            **Hub PoC**: Confirm `[Event]` or `[Support]` issue opened in 
+            **Hub PoC**: Confirm `[Event]` or `[Support]` issue opened in
             [2i2c-org/infrastructure](https://github.com/2i2c-org/infrastructure/issues)
-            in response to ticket ([example](https://github.com/2i2c-org/infrastructure/issues/5466))
+            in response to ticket
+            ([example](https://github.com/2i2c-org/infrastructure/issues/5466))
         - label: >
-            **Hub PoC**: Add new password and dates to 
-            [workshop password spreadsheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=1793413915).
+            **Hub PoC**: Add new password and dates to  [workshop password
+            spreadsheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=1793413915).
         - label: >
             **Organizer**: Two weeks before event. I have tested the default hub
-            images on the nmfs-openscapes.2i2c.cloud hub or conferred with hub 
+            images on the nmfs-openscapes.2i2c.cloud hub or conferred with hub
             PoC on plan for a workshop specific image.
         - label: >
-            **Organizer**: In the week before the event (or when hub PoC indicates
-            password should be live). I tested that the workshop password works 
-            and images work.
+            **Organizer**: In the week before the event (or when hub PoC
+            indicates password should be live). I tested that the workshop
+            password works  and images work.
         - label: >
-            **Organizer**: After the event, open an 
-            [issue](https://github.com/NMFS-Openscapes/workshop-planning/issues/new?template=NMFS-openscapes-workshop-reporting-template.md) 
+            **Organizer**: After the event, open an
+            [issue](https://github.com/NMFS-Openscapes/workshop-planning/issues/new?template=NMFS-openscapes-workshop-reporting-template.md)
             in the Workshop Planning repo to report back.
         - label: >
             **Hub PoC**: After event, put in a 2i2c ticket to reset password.
         - label: >
             **Hub PoC**: After event, log in to the hub as admin, enumerate the
-            participant directories and update the workshop spreadsheet with the 
+            participant directories and update the workshop spreadsheet with the
             actual number of participants.
         - label: >
             **Hub PoC**: After event, delete the participant directories.
         - label: >
             **Hub PoC**: Close the issue. If the workshop was completed, close
-            as "completed". If the workshop was cancelled before being held, 
-            close as "Not Planned" and note in the comments that it was cancelled.
+            as "completed". If the workshop was cancelled before being held,
+            close as "Not Planned" and note in the comments that it was
+            cancelled.

--- a/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
+++ b/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
@@ -165,9 +165,9 @@ body:
         - label: >
             **Organizer**: Submit a ticket by email to 2i2c for the workshop and
             request a new password for the workshop, [as per
-            instructions](https://openscapes.cloud/password-access.html),
-            cc'ing hub PoC (@ateucher; andy [at] openscapes [dot] org) and
-            @eeholmes (eli [dot] holmes [at] noaa [dot] gov). You will receive
+            instructions](https://openscapes.cloud/password-access.html), cc'ing
+            hub PoC (@ateucher; andy [at] openscapes [dot] org) and @eeholmes
+            (eli [dot] holmes [at] noaa [dot] gov). You will receive
             confirmation of the new password for the workshop from 2i2c once it
             is reset.
         - label: >

--- a/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
+++ b/.github/ISSUE_TEMPLATE/01-nmfs-openscapes-workshop-template-form.yml
@@ -184,11 +184,11 @@ body:
             password should be live). I tested that the workshop password works 
             and images work.
         - label: >
-            **Hub PoC**: After event, put in a 2i2c ticket to reset password.
-        - label: >
             **Organizer**: After the event, open an 
             [issue](https://github.com/NMFS-Openscapes/workshop-planning/issues/new?template=NMFS-openscapes-workshop-reporting-template.md) 
             in the Workshop Planning repo to report back.
+        - label: >
+            **Hub PoC**: After event, put in a 2i2c ticket to reset password.
         - label: >
             **Hub PoC**: After event, log in to the hub as admin, enumerate the
             participant directories and update the workshop spreadsheet with the 


### PR DESCRIPTION
I have added an ["auto-add" workflow](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically) to the [Main-Planning project](https://github.com/orgs/nmfs-openscapes/projects/35) so that when a workshop issue is opened it gets added to the Project with a "ToDo" status.

2i2c has also [added admin access](https://github.com/2i2c-org/infrastructure/pull/8177) to the workshop hub, so the hub PoC (ie @ateucher) can do the directory counting and cleanup, and 2i2c  just needs to do the password reset. I updated the checklist to reflect that.